### PR TITLE
check if user specified cvsrepo exists and is a cvs repo

### DIFF
--- a/cvs2gitdump.py
+++ b/cvs2gitdump.py
@@ -100,6 +100,21 @@ def main():
     while cvsroot[-1] == '/':
         cvsroot = cvsroot[:-1]
 
+    if (not os.path.exists(cvsroot)):
+        print >>sys.stderr, "error: %s: no such directory" % cvsroot
+        sys.exit(1)
+    if (not os.path.isdir(cvsroot)):
+        print >>sys.stderr, "error: %s: not a directory" % cvsroot
+        sys.exit(1)
+
+    p = cvsroot + "/" + "CVSROOT"
+    if (not os.path.exists(p)):
+        print >>sys.stderr, "error: %s: no such directory" % p
+        sys.exit(1)
+    if (not os.path.isdir(p)):
+        print >>sys.stderr, "error: %s: not a directory" % p
+        sys.exit(1)
+
     if len(args) == 2:
         do_incremental = True
         git = subprocess.Popen(['git', '--git-dir=' + args[1], 'log',


### PR DESCRIPTION
Yasuoka San,

I thought it would be good for cvs2gitdump
to complain if user specified cvsrepo argument
a. does not exist
b. is not a directory
c. does not have a CVSROOT subdirectory (I am assuming every CVS
repository has one. I could be wrong).

Then there is good chance the user is not making an error.

Thanks.

Dinesh